### PR TITLE
Moves class side `#reset` method to the `class initialization` protocol

### DIFF
--- a/repository/Fuel-Platform-Core.package/FLPlatform.class/class/reset.st
+++ b/repository/Fuel-Platform-Core.package/FLPlatform.class/class/reset.st
@@ -1,3 +1,3 @@
-initialization
+class initialization
 reset
 	Current := nil


### PR DESCRIPTION
Hi! 👋 - please see #1 and https://github.com/pharo-project/pharo/issues/2607 for details.

(I'm _guessing_ this needs to go into `stable` as that's what's included in the current Pharo10 image? Please correct me if I'm wrong).